### PR TITLE
Fix Footer

### DIFF
--- a/_web/_includes/footer.html
+++ b/_web/_includes/footer.html
@@ -21,7 +21,7 @@
 <hr>
 <div class="container span11">
   <small>
-    Originally built at  <a href="http://boston.musichackday.org/">Music Hack Day @ MIT</a> by
+    Originally built at  {% if page.app == 'jukebox' %}<a href="http://boston.musichackday.org/">Music Hack Day @ MIT</a>{% elsif page.app == 'canonizer' %}SXSW Music Hack Championship 2014{% endif %} by
     <a href="http://twitter.com/plamere"> Paul Lamere </a>
       Now hosted by <a href="{{ site.data.var.git }}"> UnderMybrella </a> and
       powered by <a href="http://http://spotify.com/">Spotify. </a>


### PR DESCRIPTION
With the Jekyll-ization of the site, I accidentally put the Jukebox footer on the Canonizer which incorrectly states it were it was originally built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/32)
<!-- Reviewable:end -->
