### PR TITLE
Added SQLServer Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ working/
 !/src/main/kotlin/org/abimon/eternalJukebox/data/audio
 /data/
 web
+build
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation "com.h2database:h2:1.4.196"
     implementation "mysql:mysql-connector-java:5.1.45"
+    compile  "com.microsoft.sqlserver:mssql-jdbc:8.2.2.jre8"
     implementation "com.zaxxer:HikariCP:2.7.7"
     implementation "com.google.cloud.sql:mysql-socket-factory:1.0.5"
 

--- a/src/main/kotlin/org/abimon/eternalJukebox/data/database/JDBCDatabase.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/data/database/JDBCDatabase.kt
@@ -2,6 +2,7 @@ package org.abimon.eternalJukebox.data.database
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import java.sql.DriverManager;
 
 object JDBCDatabase: HikariDatabase() {
     override val ds: HikariDataSource
@@ -10,7 +11,10 @@ object JDBCDatabase: HikariDatabase() {
         Class.forName("com.mysql.jdbc.Driver")
             .getDeclaredConstructor()
             .newInstance()
-
+	    Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver")
+            .getDeclaredConstructor()
+            .newInstance()
+	
         val config = HikariConfig("hikari.properties")
         config.jdbcUrl = databaseOptions["jdbcUrl"]?.toString() ?: throw IllegalStateException("jdbcUrl was not provided!")
 


### PR DESCRIPTION
Hey again!

So I've made some changes to allow for Microsoft SQL Server to be used as the SQL Server backend.

I thought initially it'd just be a driver, but a lot of the queries used in EternalJukebox needed some adjustments to be compatible with T-SQL's syntax.

The MERGE statements you're seeing is how upserts are implemented in T-SQL, and checking that a table exists is a little more involved in T-SQL (should be able to see what I was doing with it).

I've tested this. It builds, and DB functions work on Microsoft SQL Server with these changes in play. 
(Mainly I was checking that my check for mysql or sqlserver was working, which it does)

I haven't tested mysql, but I could spin up a box and try it out if you wish.

Please let me know if you have any questions!