### PR TITLE
[Fix] Add delay between shortId updates

### DIFF
--- a/src/main/kotlin/org/abimon/eternalJukebox/data/database/HikariDatabase.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/data/database/HikariDatabase.kt
@@ -607,9 +607,9 @@ abstract class HikariDatabase : IDatabase {
 
                         insert.executeBatch()
                     }
+                    
+                    delay(SHORT_ID_UPDATE_TIME_MS)
                 }
-                 
-                 delay(TIME_BETWEEN_UPDATES_MS)
             }
         }
 

--- a/src/main/kotlin/org/abimon/eternalJukebox/data/database/HikariDatabase.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/data/database/HikariDatabase.kt
@@ -608,6 +608,8 @@ abstract class HikariDatabase : IDatabase {
                         insert.executeBatch()
                     }
                 }
+                 
+                 delay(TIME_BETWEEN_UPDATES_MS)
             }
         }
 


### PR DESCRIPTION
Hi! Forgive the lack of terminology here, I don't know Kotlin.

Currently, there is no delay at the end of the shortId update thread. As a result, it executes constantly, eating up a whole cpu core.

I've done a 1-line change to add this delay to the end of the loop; I believe it was omitted by mistake.

Thanks for the hard work, this project does some amazing and sometimes funny things to tracks :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/67)
<!-- Reviewable:end -->
