### PR TITLE
Remove timout for app's initial connection to database. Addresses #96

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+.gradle/
 .idea/
 .vertx/
 EternalJukebox.iml

--- a/src/main/kotlin/org/abimon/eternalJukebox/data/database/JDBCDatabase.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/data/database/JDBCDatabase.kt
@@ -16,6 +16,7 @@ object JDBCDatabase: HikariDatabase() {
 
         config.username = databaseOptions["username"]?.toString()
         config.password = databaseOptions["password"]?.toString()
+        config.initializationFailTimeout = 0
 
         val cloudSqlInstance = databaseOptions["cloudSqlInstance"]?.toString()
 


### PR DESCRIPTION
This should fix #96 by allowing the app to retry connections to the database automatically. Will still fail properly in the event of other issues such as database misconfiguration or the database becoming unavailable after app startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/97)
<!-- Reviewable:end -->
