### PR TITLE
Fixed bug with youtube-dl max-filesize parameter

### DIFF
--- a/yt.bat
+++ b/yt.bat
@@ -1,1 +1,1 @@
-youtube-dl %1 -f best --audio-format %3 -x -o %2 --max-filesize 100m
+youtube-dl %1 -f "best[filesize<100m]" --audio-format %3 -x -o %2

--- a/yt.sh
+++ b/yt.sh
@@ -1,1 +1,1 @@
-youtube-dl $1 -f "best" --audio-format $3 -x -o $2 --max-filesize 100m
+youtube-dl $1 -f "best[filesize<100m]" --audio-format $3 -x -o $2


### PR DESCRIPTION
This bug caused most songs to fail to load due to ``--max-filesize`` somehow conflicting with ``-f "best"`` and similar. A functionally equal workaround was to change the format parameter to ``-f "best[filesize<100m]"``.

This should fix some (if not all) of the issues where the page goes blank after "Loading track".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/121)
<!-- Reviewable:end -->
