### PR TITLE
Fixed maven url and added --no-playlist flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url 'https://jitpack.io' }
-    maven { url 'https://maven.abimon.org' }
+    maven { url 'https://maven.brella.dev' }
 }
 
 ext {

--- a/yt.bat
+++ b/yt.bat
@@ -1,1 +1,1 @@
-youtube-dl %1 -f best --audio-format %3 -x -o %2 --max-filesize 100m
+youtube-dl %1 -f best --audio-format %3 -x -o %2 --max-filesize 100m --no-playlist

--- a/yt.sh
+++ b/yt.sh
@@ -1,1 +1,1 @@
-youtube-dl $1 -f "best" --audio-format $3 -x -o $2 --max-filesize 100m
+youtube-dl $1 -f "best" --audio-format $3 -x -o $2 --max-filesize 100m --no-playlist


### PR DESCRIPTION
Updated deprecated maven url in build.gradle as per #108 
Added the `--no-playlist` flag to the ytdl scripts to stop attempting to download entire playlists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/155)
<!-- Reviewable:end -->
