### PR TITLE
[Docker] Switched to yt-dlp and python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM adoptopenjdk:8-jdk-hotspot as deps
 
 WORKDIR /EternalJukebox
 
-RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl \
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/youtube-dl \
     && chmod a+rx /usr/local/bin/youtube-dl\
     && apt-get update \
-    && apt-get install ffmpeg gettext python -y \
+    && apt-get install ffmpeg gettext python3 -y \
     && apt-get clean \
     && touch hikari.properties
 


### PR DESCRIPTION
Switched to using yt-dlp for faster downloading from YouTube & python3 because yt-dlp requires that.