### PR TITLE
Switch to yt-dlp for all platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM adoptopenjdk:8-jdk-hotspot as deps
 
 WORKDIR /EternalJukebox
 
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/youtube-dl \
-    && chmod a+rx /usr/local/bin/youtube-dl\
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp \
+    && chmod a+rx /usr/local/bin/yt-dlp \
     && apt-get update \
     && apt-get install ffmpeg gettext python3 -y \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM adoptopenjdk:8-jdk-hotspot as deps
 
 WORKDIR /EternalJukebox
 
-RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl \
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/youtube-dl \
     && chmod a+rx /usr/local/bin/youtube-dl\
     && apt-get update \
-    && apt-get install ffmpeg gettext python -y \
+    && apt-get install ffmpeg gettext python3 -y \
     && apt-get clean \
     && touch hikari.properties
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ For Ubuntu or Debian-based distributions execute `sudo apt-get install default-j
 ##### Fedora and CentOS
 There is a tutorial for installing java on Fedora and CentOS at https://www.digitalocean.com/community/tutorials/how-to-install-java-on-centos-and-fedora   
 
-### Youtube-dl:
+### Yt-dlp (a more up-to-date fork of Youtube-dl):
 ##### Windows
-Download the .exe at https://yt-dl.org/latest/youtube-dl.exe and place it in `C:\Windows\`, or in another folder on the PATH.
+Download the .exe at https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe and place it in `C:\Windows\`, or in another folder on the PATH.
 ##### Linux
 Use these commands in the terminal to install youtube-dl on Linux:  
-`sudo curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl`   
-`sudo chmod a+rx /usr/local/bin/youtube-dl`
+`sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp`   
+`sudo chmod a+rx /usr/local/bin/yt-dlp`
 
 ### ffmpeg:
 ##### Windows

--- a/yt.bat
+++ b/yt.bat
@@ -1,1 +1,1 @@
-youtube-dl %1 -f best --audio-format %3 -x -o %2 --max-filesize 100m --no-playlist
+yt-dlp %1 -f best --audio-format %3 -x -o %2 --max-filesize 100m --no-playlist

--- a/yt.sh
+++ b/yt.sh
@@ -1,1 +1,1 @@
-youtube-dl $1 -f "best" --audio-format $3 -x -o $2 --max-filesize 100m --no-playlist
+yt-dlp $1 -f "best" --audio-format $3 -x -o $2 --max-filesize 100m --no-playlist


### PR DESCRIPTION
Even though the original youtube-dl repository was taken over by new maintainers and is getting updates, they aren't putting out releases. Therefore this PR switches to yt-dlp

Supersedes #157 

This is @IanSteg 's idea for simple update in Dockerfile done properly (download to correct location and change program in script), along with instructions for other platforms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/166)
<!-- Reviewable:end -->
