### PR TITLE
Gradle Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o 
 
 # build jar with gradle
 
-FROM gradle:jdk8 as gradle-build
+FROM gradle:7-jdk8 as gradle-build
 
 WORKDIR /home/gradle/project
 


### PR DESCRIPTION
This small change enforces the usage of the Gradle 7 Docker image as this repository now contains code that is no longer supported by Gradle 8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/UnderMybrella/EternalJukebox/173)
<!-- Reviewable:end -->
