### PR TITLE
Force gradle tag to 7.6.1-jdk8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o 
 
 # build jar with gradle
 
-FROM gradle:jdk8 as gradle-build
+FROM gradle:7.6.1-jdk8 as gradle-build
 
 WORKDIR /home/gradle/project
 

--- a/config_template.json
+++ b/config_template.json
@@ -26,7 +26,7 @@
     "apiKey": "<API_KEY>"
   },
   "workerExecuteTimeComment": "How long blocking workers can go for (in ns)",
-  "workerExecuteTime": 1200000000000
+  "workerExecuteTime": 1200000000000,
 
   "databaseTypeComment": "Can either be JDBC or H2",
   "databaseTypeComment2": "If H2, you'll need to provide 'databaseName' under options, or leave it blank to default to 'eternal_jukebox'",


### PR DESCRIPTION
Fix for build error `java.lang.NoSuchMethodError: org.gradle.api.artifacts.dsl.DependencyHandler.registerTransform`